### PR TITLE
truffle-contract-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ This repository features a list of awesome Truffle plugins for any purpose. Beca
 
 * [truffle-plugin-verify](https://github.com/rkalis/truffle-plugin-verify) - Verifies smart contracts on Etherscan.
 * [truffle-security](https://github.com/ConsenSys/truffle-security) - Runs MythX security analysis on smart contracts.
+* [truffle-contract-size](https://github.com/IoBuilders/truffle-contract-size) - Displays the size of smart contracts in kilobytes.


### PR DESCRIPTION
This Truffle plugin displays the contract size of all or a selection of your smart contracts in kilobytes.