### PR TITLE
Add truffle-plugin-abigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This repository features a list of awesome Truffle plugins for any purpose. Beca
 * [truffle-plugin-verify](https://github.com/rkalis/truffle-plugin-verify) - Verifies smart contracts on Etherscan.
 * [truffle-security](https://github.com/ConsenSys/truffle-security) - Runs MythX security analysis on smart contracts.
 * [truffle-contract-size](https://github.com/IoBuilders/truffle-contract-size) - Displays the size of smart contracts in kilobytes.
+* [truffle-plugin-abigen](https://github.com/ChainSafe/truffle-plugin-abigen) - Generates Geth-compatible [abigen](https://github.com/ethereum/go-ethereum/wiki/Native-DApps:-Go-bindings-to-Ethereum-contracts) data for building Golang bindings for Ethereum contracts


### PR DESCRIPTION
(h/t to @GregTheGreek, of course for doing the work here)

This PR adds a link to a new plugin, to support the generation of Golang contract bindings 